### PR TITLE
fix(seccomp): add Linux AIO syscalls for UFFD+hugepages snapshot restore

### DIFF
--- a/resources/seccomp/aarch64-unknown-linux-musl.json
+++ b/resources/seccomp/aarch64-unknown-linux-musl.json
@@ -50,6 +50,22 @@
                 "comment": "Used for creating io_uring completion event, on drive patch"
             },
             {
+                "syscall": "io_setup",
+                "comment": "Used by kernel AIO during UFFD+hugepages snapshot restore on aarch64"
+            },
+            {
+                "syscall": "io_destroy",
+                "comment": "Cleanup for io_setup AIO context"
+            },
+            {
+                "syscall": "io_submit",
+                "comment": "Submit AIO requests during UFFD+hugepages snapshot restore"
+            },
+            {
+                "syscall": "io_getevents",
+                "comment": "Wait for AIO completion during UFFD+hugepages snapshot restore"
+            },
+            {
                 "syscall": "io_uring_enter",
                 "comment": "Used for submitting io_uring requests"
             },

--- a/resources/seccomp/x86_64-unknown-linux-musl.json
+++ b/resources/seccomp/x86_64-unknown-linux-musl.json
@@ -50,6 +50,22 @@
                 "comment": "Used for creating io_uring completion event, on drive patch"
             },
             {
+                "syscall": "io_setup",
+                "comment": "Used by kernel AIO during UFFD+hugepages snapshot restore"
+            },
+            {
+                "syscall": "io_destroy",
+                "comment": "Cleanup for io_setup AIO context"
+            },
+            {
+                "syscall": "io_submit",
+                "comment": "Submit AIO requests during UFFD+hugepages snapshot restore"
+            },
+            {
+                "syscall": "io_getevents",
+                "comment": "Wait for AIO completion during UFFD+hugepages snapshot restore"
+            },
+            {
                 "syscall": "io_uring_enter",
                 "comment": "Used for submitting io_uring requests"
             },


### PR DESCRIPTION
## Summary
- Add `io_setup`, `io_destroy`, `io_submit`, `io_getevents` to the VMM thread seccomp filter on both aarch64 and x86_64

## Problem
During UFFD+hugepages snapshot restore on aarch64, the kernel's async I/O subsystem calls `io_setup` (syscall 0 on aarch64) which is not in the seccomp allowlist. This causes:
- `SIGSYS` (signal 31) delivered to the `fc_vmm` thread
- Firecracker exits with code **148** (`BadSyscall`)
- The issue is **intermittent** — only occurs during template builds that use UFFD with hugepages

## Root Cause
Confirmed via bpftrace on an ARM64 host:

```
bpftrace -e 'tracepoint:signal:signal_generate
  /args->sig == 31 && comm == "fc_vmm"/ {
    printf("SIGSYS for fc_vmm pid=%d, syscall=%d\n",
      pid, args->errno);
  }'
```

Output: `SIGSYS for fc_vmm pid=XXXX, syscall=0` — syscall 0 on aarch64 is `io_setup`.

The modern `io_uring_*` syscalls are already in the filter, but the legacy Linux AIO syscalls (`io_setup`/`io_destroy`/`io_submit`/`io_getevents`) are missing. Something in the UFFD hugepages code path triggers the legacy AIO API on aarch64.

## Changes
Added to `vmm` thread filter in both `aarch64-unknown-linux-musl.json` and `x86_64-unknown-linux-musl.json`:
- `io_setup` — initialize AIO context
- `io_destroy` — cleanup AIO context
- `io_submit` — submit AIO requests
- `io_getevents` — wait for AIO completion

## Test plan
- [ ] Build Firecracker for aarch64 with updated seccomp filter
- [ ] Run UFFD+hugepages template build on ARM64 — should no longer hit BadSyscall
- [ ] Verify x86_64 builds still work (syscalls added for consistency)

🤖 Generated with [Claude Code](https://claude.com/claude-code)