### PR TITLE
fix(uffd): register guest memory with WRITE_PROTECT in addition to MISSING

### DIFF
--- a/src/vmm/Cargo.toml
+++ b/src/vmm/Cargo.toml
@@ -46,7 +46,7 @@ serde = { version = "1.0.228", features = ["derive", "rc"] }
 serde_json = "1.0.149"
 slab = "0.4.12"
 thiserror = "2.0.18"
-userfaultfd = "0.9.0"
+userfaultfd = { version = "0.9.0", features = ["linux5_7"] }
 utils = { path = "../utils" }
 uuid = "1.23.0"
 vhost = { version = "0.15.0", features = ["vhost-user-frontend"] }

--- a/src/vmm/src/persist.rs
+++ b/src/vmm/src/persist.rs
@@ -14,7 +14,7 @@ use std::sync::{Arc, Mutex};
 
 use semver::Version;
 use serde::{Deserialize, Serialize};
-use userfaultfd::{FeatureFlags, Uffd, UffdBuilder};
+use userfaultfd::{FeatureFlags, RegisterMode, Uffd, UffdBuilder};
 use vmm_sys_util::sock_ctrl_msg::ScmSocket;
 
 #[cfg(target_arch = "aarch64")]
@@ -553,9 +553,23 @@ fn guest_memory_from_uffd(
         .create()
         .map_err(GuestMemoryFromUffdError::Create)?;
 
+    // Register every region for both MISSING and WRITE_PROTECT faults.
+    //
+    // MISSING is needed so the orchestrator's UFFD handler is woken up the first time the guest
+    // touches a page that has not yet been populated from the snapshot's memory file.
+    //
+    // WRITE_PROTECT is needed so the handler can keep pages it serves in a write-protected state
+    // (via UFFDIO_COPY_MODE_WP) and observe subsequent writes as new faults — the standard CoW
+    // tracking pattern that lets the orchestrator know which pages got dirtied after restore.
+    // Without WRITE_PROTECT registration, UFFDIO_COPY with MODE_WP fails synchronously with
+    // EINVAL on the very first read fault, breaking the snapshot resume path.
     for mem_region in guest_memory.iter() {
-        uffd.register(mem_region.as_ptr().cast(), mem_region.size() as _)
-            .map_err(GuestMemoryFromUffdError::Register)?;
+        uffd.register_with_mode(
+            mem_region.as_ptr().cast(),
+            mem_region.size() as _,
+            RegisterMode::MISSING | RegisterMode::WRITE_PROTECT,
+        )
+        .map_err(GuestMemoryFromUffdError::Register)?;
     }
 
     send_uffd_handshake(mem_uds_path, &backend_mappings, &uffd)?;


### PR DESCRIPTION
## Changes

In `guest_memory_from_uffd` (`src/vmm/src/persist.rs`), switch the per-region UFFD registration from the `Uffd::register(...)` convenience wrapper (which uses `UFFDIO_REGISTER_MODE_MISSING` only) to `Uffd::register_with_mode(... MISSING | WRITE_PROTECT)`.

To use `RegisterMode::WRITE_PROTECT`, also enable the `linux5_7` feature on the `userfaultfd` crate dependency in `src/vmm/Cargo.toml`. The flag is named after the kernel that introduced `UFFDIO_WRITEPROTECT` (Linux 5.7), which is well below Firecracker's supported kernel range.

## Reason

Any UFFD handler that asks the kernel to keep a copied page write-protected by passing `UFFDIO_COPY_MODE_WP` got a synchronous `EINVAL` on the very first read fault, because the destination range was never registered with `UFFDIO_REGISTER_MODE_WP`. WRITE_PROTECT registration is what enables the standard CoW snapshot pattern:

1. Handler receives a MISSING fault, serves the page via `UFFDIO_COPY` with `MODE_WP` so the page lands write-protected.
2. Guest writes to the page; kernel re-faults to the handler.
3. Handler now knows which pages were dirtied after restore (without MODE_WP it cannot distinguish "page was just populated" from "page was modified after population").

Without WP registration, step 1 fails immediately with `EINVAL`, breaking the resume path for any handler that opts into WP tracking. We hit this in practice with the e2b-dev/infra orchestrator's UFFD handler.

This change is a strict superset of the previous registration. Handlers that never pass `MODE_WP` behave exactly as before — `WRITE_PROTECT` registration on its own is a no-op until the handler explicitly write-protects pages.

### Repro

Trivial against the unpatched binary:

```rust
// inside any UFFD handler responding to a MISSING fault
let mut copy = uffdio_copy { ... mode: UFFDIO_COPY_MODE_WP, .. };
ioctl(uffd, UFFDIO_COPY, &mut copy);  // -> EINVAL on stock FC
                                      // -> Ok with this patch
```

Reproduced end-to-end from the orchestrator's resume path: every read fault returned `failed to handle uffd: failed to handle uffd: invalid argument` (the propagated `EINVAL`) until WRITE_PROTECT was registered on the FC side.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

- [ ] I have read and understand `CONTRIBUTING.md`.
- [x] `cargo check -p vmm --target x86_64-unknown-linux-gnu` passes.
- [x] `cargo build -p vmm --target x86_64-unknown-linux-gnu` passes.
- [ ] `tools/devtool checkbuild --all` — not run locally (this is a draft).
- [ ] `tools/devtool checkstyle` — not run locally (this is a draft).
- [x] I have described what is done in these changes, why they are needed, and how they are solving the problem.
- [ ] CHANGELOG.md entry — happy to add if reviewers want one.
- [ ] I have tested all new and changed functionalities in unit tests and/or integration tests.
- [ ] I have linked an issue to every new `TODO`.

______________________________________________________________________

- [x] This functionality cannot be added in `rust-vmm` (it's purely a Firecracker registration change).