### PR TITLE
fix: saving/restoring async IO engine transport state

### DIFF
--- a/src/vmm/src/devices/virtio/block/device.rs
+++ b/src/vmm/src/devices/virtio/block/device.rs
@@ -82,13 +82,6 @@ impl Block {
         }
     }
 
-    pub fn prepare_save(&mut self) {
-        match self {
-            Self::Virtio(b) => b.prepare_save(),
-            Self::VhostUser(b) => b.prepare_save(),
-        }
-    }
-
     pub fn process_virtio_queues(&mut self) -> Result<(), InvalidAvailIdx> {
         match self {
             Self::Virtio(b) => b.process_virtio_queues(),
@@ -225,6 +218,13 @@ impl VirtioDevice for Block {
         if self.is_activated() {
             info!("kick block {}.", self.id());
             self.process_virtio_queues();
+        }
+    }
+
+    fn prepare_save(&mut self) {
+        match self {
+            Self::Virtio(b) => b.prepare_save(),
+            Self::VhostUser(b) => b.prepare_save(),
         }
     }
 }

--- a/src/vmm/src/devices/virtio/device.rs
+++ b/src/vmm/src/devices/virtio/device.rs
@@ -169,6 +169,9 @@ pub trait VirtioDevice: AsAny + Send {
 
     /// Kick the device, as if it had received external events.
     fn kick(&mut self) {}
+
+    /// Prepare the device for saving its state
+    fn prepare_save(&mut self) {}
 }
 
 impl fmt::Debug for dyn VirtioDevice {

--- a/src/vmm/src/devices/virtio/net/device.rs
+++ b/src/vmm/src/devices/virtio/net/device.rs
@@ -938,26 +938,6 @@ impl Net {
 
         Ok(())
     }
-
-    /// Prepare saving state
-    pub fn prepare_save(&mut self) {
-        // We shouldn't be messing with the queue if the device is not activated.
-        // Anyways, if it isn't there's nothing to prepare; we haven't parsed any
-        // descriptors yet from it and we can't have a deferred frame.
-        if !self.is_activated() {
-            return;
-        }
-
-        // Give potential deferred RX frame to guest
-        self.rx_buffer.finish_frame(&mut self.queues[RX_INDEX]);
-        // Reset the parsed available descriptors, so we will re-parse them
-        self.queues[RX_INDEX].next_avail -=
-            Wrapping(u16::try_from(self.rx_buffer.parsed_descriptors.len()).unwrap());
-        self.rx_buffer.parsed_descriptors.clear();
-        self.rx_buffer.iovec.clear();
-        self.rx_buffer.used_bytes = 0;
-        self.rx_buffer.used_descriptors = 0;
-    }
 }
 
 impl VirtioDevice for Net {
@@ -1068,6 +1048,26 @@ impl VirtioDevice for Net {
             info!("kick net {}.", self.id());
             self.process_virtio_queues();
         }
+    }
+
+    /// Prepare saving state
+    fn prepare_save(&mut self) {
+        // We shouldn't be messing with the queue if the device is not activated.
+        // Anyways, if it isn't there's nothing to prepare; we haven't parsed any
+        // descriptors yet from it and we can't have a deferred frame.
+        if !self.is_activated() {
+            return;
+        }
+
+        // Give potential deferred RX frame to guest
+        self.rx_buffer.finish_frame(&mut self.queues[RX_INDEX]);
+        // Reset the parsed available descriptors, so we will re-parse them
+        self.queues[RX_INDEX].next_avail -=
+            Wrapping(u16::try_from(self.rx_buffer.parsed_descriptors.len()).unwrap());
+        self.rx_buffer.parsed_descriptors.clear();
+        self.rx_buffer.iovec.clear();
+        self.rx_buffer.used_bytes = 0;
+        self.rx_buffer.used_descriptors = 0;
     }
 }
 

--- a/src/vmm/src/lib.rs
+++ b/src/vmm/src/lib.rs
@@ -444,6 +444,12 @@ impl Vmm {
     /// Saves the state of a paused Microvm.
     pub fn save_state(&mut self, vm_info: &VmInfo) -> Result<MicrovmState, MicrovmStateError> {
         use self::MicrovmStateError::SaveVmState;
+        // We need to save device state before saving KVM state.
+        // Some devices, (at the time of writing this comment block device with async engine)
+        // might modify the VirtIO transport and send an interrupt to the guest. If we save KVM
+        // state before we save device state, that interrupt will never be delivered to the guest
+        // upon resuming from the snapshot.
+        let device_states = self.device_manager.save();
         let vcpu_states = self.save_vcpu_states()?;
         let kvm_state = self.kvm.save_state();
         let vm_state = {
@@ -458,7 +464,6 @@ impl Vmm {
                 self.vm.save_state(&mpidrs).map_err(SaveVmState)?
             }
         };
-        let device_states = self.device_manager.save();
 
         Ok(MicrovmState {
             vm_info: vm_info.clone(),


### PR DESCRIPTION
Cherry-pick from https://github.com/firecracker-microvm/firecracker/pull/5582 (1.15 upstream).

When saving the state of a microVM with one or more block devices backed by the async IO engine, we need to take a few steps extra steps before serializing the state to the disk, as we need to make sure that there aren't any pending io_uring requests that have not been handled by the kernel yet. For these types of devices that need that we call a prepare_save() hook before serializing the device state.

If there are indeed pending requests, once we handle them we need to let the guest know, by adding the corresponding VirtIO descriptors to the used ring. Moreover, since we use notification suppression, this might or might not require us to send an interrupt to the guest.

Now, when we save the state of a VirtIO device, we save the device specific state **and** the transport (MMIO or PCI) state along with it.

There were a few issues with how we were doing the serialization:

1. We were saving the transport state before we run the prepare_save() hook. The transport state includes information such as the `interrupt_status` in MMIO or `MSI-X config` in PCI. prepare_save() in the case of async IO might change this state, so us running it after saving the transport state essentially looses information.
2. We were saving the devices states after saving the KVM state. This is problematic because, if prepare_save() sends an interrupt to the guest we don't save that "pending interrupt" bit of information in the snapshot.

These two issues, were making microVMs with block devices backed by async IO freeze in some cases post snapshot resume, since the guest is stuck in the kernel waiting for some notification for the device emulation which never arrives.

Currently, this is only a problem with virtio-block with async IO engine. The only other device using the prepare_save() hook is currently virtio-net, but this one doesn't modify any VirtIO state, neither sends interrupts.

Fix this by ensuring the correct ordering of operations during the snapshot phase.