### PR TITLE
Make async IO request submission more robust and fail early in case of in-kernel errors

### DIFF
--- a/src/vmm/src/devices/virtio/block/virtio/device.rs
+++ b/src/vmm/src/devices/virtio/block/virtio/device.rs
@@ -722,9 +722,12 @@ impl VirtioBlock {
     }
 
     fn drain_and_flush(&mut self, discard: bool) {
-        if let Err(err) = self.disk.file_engine.drain_and_flush(discard) {
-            error!("Failed to drain ops and flush block data: {:?}", err);
-        }
+        // If draining and/or flushing failed, hard crash to avoid continuing with a potentially
+        // not consistent underlying filesystem in the disk.
+        self.disk
+            .file_engine
+            .drain_and_flush(discard)
+            .expect("virtio-block: failed to drain ops and flush block data");
     }
 
     /// Prepare device for being snapshotted.

--- a/src/vmm/src/io_uring/queue/submission.rs
+++ b/src/vmm/src/io_uring/queue/submission.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use std::fmt::Debug;
-use std::io::Error as IOError;
+use std::io::{Error as IOError, ErrorKind};
 use std::mem;
 use std::num::Wrapping;
 use std::os::unix::io::RawFd;
@@ -130,26 +130,39 @@ impl SubmissionQueue {
         if min_complete > 0 {
             flags |= generated::IORING_ENTER_GETEVENTS;
         }
-        // SAFETY: Safe because values are valid and we check the return value.
-        let submitted = SyscallReturnCode(unsafe {
-            libc::syscall(
-                libc::SYS_io_uring_enter,
-                self.io_uring_fd,
-                self.to_submit,
-                min_complete,
-                flags,
-                std::ptr::null::<libc::sigset_t>(),
-            )
-        })
-        .into_result()?;
-        // It's safe to convert to u32 since the syscall didn't return an error.
-        let submitted = u32::try_from(submitted).unwrap();
 
-        // This is safe since submitted <= self.to_submit. However we use a saturating_sub
-        // for extra safety.
-        self.to_submit = self.to_submit.saturating_sub(submitted);
-
-        Ok(submitted)
+        // The number of retries is completely arbitrary here. I assume that this
+        // will happen rarely and that if it happens subsequent retry will immediately
+        // succeed. If we fall in a storm of interrupts something else is probably wrong
+        // so let the consumer know.
+        let mut eintr_retries = 3;
+        loop {
+            // SAFETY: Safe because values are valid and we check the return value.
+            let ret = SyscallReturnCode(unsafe {
+                libc::syscall(
+                    libc::SYS_io_uring_enter,
+                    self.io_uring_fd,
+                    self.to_submit,
+                    min_complete,
+                    flags,
+                    std::ptr::null::<libc::sigset_t>(),
+                )
+            })
+            .into_result();
+            match ret {
+                Ok(num) => {
+                    // It's safe to convert to u32 since the syscall didn't return an error.
+                    let submitted = u32::try_from(num).unwrap();
+                    self.to_submit = self.to_submit.saturating_sub(submitted);
+                    return Ok(submitted);
+                }
+                Err(err) if err.kind() == ErrorKind::Interrupted && eintr_retries > 0 => {
+                    eintr_retries -= 1;
+                    continue;
+                }
+                Err(err) => return Err(SQueueError::from(err)),
+            }
+        }
     }
 
     fn mmap(


### PR DESCRIPTION
This addresses two distinct issues with io_uring.

Firstly, `io_uring_enter()` can fail with EINTR, if it receives an interrupt while submitting work in the queue. The first commit of this PR adds some logic to make this case slightly more robust by introducing a bounded number of retries.

The second issue is related with the fact that, if an error occurs along the path of submitting and waiting io_uring work to complete, Firecracker simply logs an error and continues. This can lead to corrupted disk and snapshot state. These errors would mainly occur on conditions, such as Firecracker bugs, guest kernel bugs, or unlikely conditions on the host (e.g. memory exhaustion). All of these conditions are extremely unlikely and (most importantly we don't have a good way to recover from these.

In order to be able to catch these situations early and facilitate detection and post-mortem analysis, the second commit changes Firecracker's behaviour to crash in these scenarios. Like this, the error that causes the issue becomes very obvious, rather than hidden in an FC log. This is inline with what Firecracker does in various other similar code paths and error conditions.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [ ] I have read and understand [CONTRIBUTING.md][3].
- [ ] I have run `tools/devtool checkbuild --all` to verify that the PR passes
  build checks on all supported architectures.
- [ ] I have run `tools/devtool checkstyle` to verify that the PR passes the
  automated style checks.
- [ ] I have described what is done in these changes, why they are needed, and
  how they are solving the problem in a clear and encompassing way.
- [ ] I have updated any relevant documentation (both in code and in the docs)
  in the PR.
- [ ] I have mentioned all user-facing changes in `CHANGELOG.md`.
- [ ] If a specific issue led to this PR, this PR closes the issue.
- [ ] When making API changes, I have followed the
  [Runbook for Firecracker API changes][2].
- [ ] I have tested all new and changed functionalities in unit tests and/or
  integration tests.
- [ ] I have linked an issue to every new `TODO`.

______________________________________________________________________

- [ ] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
