### PR TITLE
docs: archive notice pointing at the release pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,13 @@
+> [!IMPORTANT]
+> **This repository is archived.** E2B's Firecracker releases are built by the fc-versions
+> pipeline in [`e2b-dev/infra`](https://github.com/e2b-dev/infra) and published under the
+> `vX.Y-<major.minor.patch>` versioning scheme to the public artifact bucket
+> (`gs://e2b-artifact-binaries/firecrackers/`). The branches and tags here remain readable
+> for reference; builds from this repository use the legacy `vX.Y.Z_<sha>` naming and
+> receive no further updates.
+
+---
+
 <picture>
    <source media="(prefers-color-scheme: dark)" srcset="docs/images/fc_logo_full_transparent-bg_white-fg.png">
    <source media="(prefers-color-scheme: light)" srcset="docs/images/fc_logo_full_transparent-bg.png">


### PR DESCRIPTION
Prepends an archive notice to the README ahead of archiving this repository: releases are built by the fc-versions pipeline in e2b-dev/infra under the `vX.Y-<major.minor.patch>` scheme and published to the public artifact bucket; the branches and tags here stay readable for reference.

Deliberately does not say where fork development moved — no private-repo references in public text.

Merge, then: archive the repository and remove it from the App installation (org-admin actions).